### PR TITLE
Add backwards compatibility renaming for --protocol

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Devlooped;
 using Spectre.Console.Cli;
 
@@ -16,7 +18,7 @@ app.Configure(config =>
     {
         Description = new Spectre.Console.Cli.Help.DescriptionStyle
         {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold), 
+            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
         },
         Usage = new Spectre.Console.Cli.Help.UsageStyle
         {
@@ -57,4 +59,5 @@ if (args.Length > 0 && args[0] == "erase")
 if (args.Length > 0 && args[0] == "store")
     args[0] = "set";
 
-await app.RunAsync(args);
+// Replace --protocol > --scheme
+await app.RunAsync(args.Select(x => x.StartsWith("--protocol", StringComparison.OrdinalIgnoreCase) ? x.Replace("--protocol", "--scheme") : x));


### PR DESCRIPTION
Which is now --scheme.

To make the option consistent across all three commands, we renamed --protocol to --scheme so we could always use the shorthand -s regardless of whether there was a -p|--password option too.

This caused older invocations to break since the protocol would be null/empty and thus a matching provider was not found (i.e. for github).

Fixes #25