### PR TITLE
Allow usage with a namespace for generic credential scoping

### DIFF
--- a/src/DeleteCommand.cs
+++ b/src/DeleteCommand.cs
@@ -1,21 +1,45 @@
-﻿using System.ComponentModel;
+﻿extern alias CredentialManager;
+using System.ComponentModel;
 using System.Threading.Tasks;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace Devlooped;
 
 [Description("Delete a stored credential.")]
-public class DeleteCommand : AsyncCommand<UrlSettings>
+public class DeleteCommand : AsyncCommand<DeleteCommand.DeleteSettings>
 {
-    public override async Task<int> ExecuteAsync(CommandContext context, UrlSettings settings)
+    public class DeleteSettings : UrlSettings
     {
-        var input = settings.ToInputs();
-        if (HostProviders.GetProvider(input) is { } provider)
+        [Description("The user or account to retrieve the password for, if using a namespace for generic credentials.")]
+        [CommandOption("-u|--username <USERNAME>", IsHidden = true)]
+        public string? Account { get; set; }
+
+        public override ValidationResult Validate()
         {
-            await provider.EraseCredentialAsync(input);
-            return 0;
+            if (Namespace != null && Account == null)
+                return ValidationResult.Error("The user or account is required when using a namespace.");
+
+            return base.Validate();
+        }
+    }
+
+    public override async Task<int> ExecuteAsync(CommandContext context, DeleteSettings settings)
+    {
+        if (settings.Namespace == null)
+        {
+            var input = settings.ToInputs();
+            if (HostProviders.GetProvider(input) is { } provider)
+            {
+                await provider.EraseCredentialAsync(input);
+                return 0;
+            }
+
+            return -1;
         }
 
-        return -1;
+        var store = CredentialManager.GitCredentialManager.CredentialManager.Create(settings.Namespace);
+        store.Remove(settings.Uri!.AbsoluteUri, settings.Account);
+        return 0;
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,52 +1,32 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Devlooped;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 // We never run interactively, since this is mostly a tool for automation/CI environments
 Environment.SetEnvironmentVariable("GCM_INTERACTIVE", "never", EnvironmentVariableTarget.Process);
 Environment.SetEnvironmentVariable("GIT_TERMINAL_PROMPT", "false", EnvironmentVariableTarget.Process);
 
+
+if (args.Contains("--version"))
+{
+    AnsiConsole.MarkupLine($"{ThisAssembly.Project.ToolCommandName} version [lime]{ThisAssembly.Project.Version}[/] ({ThisAssembly.Project.BuildDate})");
+    AnsiConsole.MarkupLine($"[link]{ThisAssembly.Git.Url}/releases/tag/{ThisAssembly.Project.BuildRef}[/]");
+    return;
+}
+
+if (args.Contains("-?"))
+    args = args.Select(x => x == "-?" ? "--help" : x).ToArray();
+if (args.Contains("-h"))
+    args = args.Select(x => x == "-h" ? "--help" : x).ToArray();
+
 var app = new CommandApp();
 app.Configure(config =>
 {
     // Change so it matches the actual user experience as a dotnet CLI extension
     config.SetApplicationName("dotnet gcm");
-
-    config.Settings.HelpProviderStyles = new Spectre.Console.Cli.Help.HelpProviderStyle
-    {
-        Description = new Spectre.Console.Cli.Help.DescriptionStyle
-        {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
-        },
-        Usage = new Spectre.Console.Cli.Help.UsageStyle
-        {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
-            Command = new Spectre.Console.Style(Spectre.Console.Color.Green, decoration: Spectre.Console.Decoration.Bold),
-            CurrentCommand = new Spectre.Console.Style(Spectre.Console.Color.Green, decoration: Spectre.Console.Decoration.Bold),
-            OptionalArgument = new Spectre.Console.Style(Spectre.Console.Color.Grey),
-            RequiredArgument = new Spectre.Console.Style(Spectre.Console.Color.White, decoration: Spectre.Console.Decoration.Bold),
-            Options = new Spectre.Console.Style(Spectre.Console.Color.Blue, decoration: Spectre.Console.Decoration.Bold),
-        },
-        Arguments = new Spectre.Console.Cli.Help.ArgumentStyle
-        {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
-            OptionalArgument = new Spectre.Console.Style(Spectre.Console.Color.Grey),
-            RequiredArgument = new Spectre.Console.Style(Spectre.Console.Color.White, decoration: Spectre.Console.Decoration.Bold),
-        },
-        Options = new Spectre.Console.Cli.Help.OptionStyle
-        {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
-            OptionalOption = new Spectre.Console.Style(Spectre.Console.Color.Grey),
-            RequiredOption = new Spectre.Console.Style(Spectre.Console.Color.Blue, decoration: Spectre.Console.Decoration.Bold),
-        },
-        Commands = new Spectre.Console.Cli.Help.CommandStyle
-        {
-            Header = new Spectre.Console.Style(Spectre.Console.Color.Yellow, decoration: Spectre.Console.Decoration.Bold),
-            RequiredArgument = new Spectre.Console.Style(Spectre.Console.Color.Blue, decoration: Spectre.Console.Decoration.Bold),
-        },
-    };
+    config.PrettyHelper();
 
     config.AddCommand<GetCommand>("get");
     config.AddCommand<DeleteCommand>("delete");

--- a/src/SpectreExtensions.cs
+++ b/src/SpectreExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace Devlooped;
+
+static class SpectreExtensions
+{
+    public static IConfigurator PrettyHelper(this IConfigurator config)
+    {
+        config.Settings.HelpProviderStyles = new Spectre.Console.Cli.Help.HelpProviderStyle
+        {
+            Description = new Spectre.Console.Cli.Help.DescriptionStyle
+            {
+                Header = new Style(Color.Yellow, decoration: Decoration.Bold),
+            },
+            Usage = new Spectre.Console.Cli.Help.UsageStyle
+            {
+                Header = new Style(Color.Yellow, decoration: Decoration.Bold),
+                Command = new Style(Color.Green, decoration: Decoration.Bold),
+                CurrentCommand = new Style(Color.Green, decoration: Decoration.Bold),
+                OptionalArgument = new Style(Color.Grey),
+                RequiredArgument = new Style(Color.White, decoration: Decoration.Bold),
+                Options = new Style(Color.Blue, decoration: Decoration.Bold),
+            },
+            Arguments = new Spectre.Console.Cli.Help.ArgumentStyle
+            {
+                Header = new Style(Color.Yellow, decoration: Decoration.Bold),
+                OptionalArgument = new Style(Color.Grey),
+                RequiredArgument = new Style(Color.White, decoration: Decoration.Bold),
+            },
+            Options = new Spectre.Console.Cli.Help.OptionStyle
+            {
+                Header = new Style(Color.Yellow, decoration: Decoration.Bold),
+                OptionalOption = new Style(Color.Grey),
+                RequiredOption = new Style(Color.Blue, decoration: Decoration.Bold),
+            },
+            Commands = new Spectre.Console.Cli.Help.CommandStyle
+            {
+                Header = new Style(Color.Yellow, decoration: Decoration.Bold),
+                RequiredArgument = new Style(Color.Blue, decoration: Decoration.Bold),
+            },
+        };
+
+        return config;
+    }
+}

--- a/src/UrlSettings.cs
+++ b/src/UrlSettings.cs
@@ -58,6 +58,10 @@ public class UrlSettings : CommandSettings
     [CommandOption("--path <PATH>")]
     public string? Path { get; set; }
 
+    [Description("Optional namespace for generic credentials that don't belong to a particular host provider.")]
+    [CommandOption("-n|--namespace", IsHidden = true)]
+    public string? Namespace { get; set; }
+
     public override ValidationResult Validate()
     {
         if (Uri != null)
@@ -65,6 +69,18 @@ public class UrlSettings : CommandSettings
             Scheme = Uri.Scheme;
             Host = Uri.Host;
             Path = Uri.GetComponents(UriComponents.Path, UriFormat.Unescaped);
+        }
+
+        if (Host == null || Scheme == null)
+            return ValidationResult.Error("Either a URL or host and scheme are required.");
+
+        if (Uri == null)
+        {
+            var builder = new UriBuilder(Scheme, Host);
+            if (Path != null)
+                builder.Path = Path;
+
+            Uri = builder.Uri;
         }
 
         return base.Validate();

--- a/src/gcm.csproj
+++ b/src/gcm.csproj
@@ -15,6 +15,9 @@
     <NoWarn>NU5118</NoWarn>
 
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+
+    <BuildDate>$([System.DateTime]::Now.ToString("yyyy-MM-dd"))</BuildDate>
+    <BuildRef>$(GITHUB_REF_NAME)</BuildRef>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,10 +25,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devlooped.CredentialManager" Version="2.5.0.1" Aliases="CredentialManager" />
     <PackageReference Include="NuGetizer" Version="1.2.1" PrivateAssets="all" />
     <PackageReference Include="Spectre.Console.Analyzer" Version="0.49.1" PrivateAssets="all" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
     <PackageReference Include="git-credential-manager" Version="2.4.1" IncludeAssets="tools" GeneratePathProperty="true" />
+    <PackageReference Include="ThisAssembly.Git" Version="1.4.3" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="1.4.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Pkggit-credential-manager)' != ''">
@@ -34,6 +40,12 @@
     <Reference Include="GitHub" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\GitHub.dll" />
     <Reference Include="GitLab" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\GitLab.dll" />
     <Reference Include="gcmcore" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\gcmcore.dll" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectProperty Include="ToolCommandName" />
+    <ProjectProperty Include="BuildDate" />
+    <ProjectProperty Include="BuildRef" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Allows passing a (for now hidden) `-n|--namespace` for usage as a generic credential tool.

Adds `--version` and `-?|-h` > `--help` automatic conversion.

Fixes #31